### PR TITLE
Handle optional gradio and fix pair normalization

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -243,7 +243,8 @@ def pair(seq, width, height):
                 continue
             feature = flatten_lst(seq[i]) + flatten_lst(seq[j])
             normalized_feature = [
-                elem if idx % 2 else elem for idx, elem in enumerate(feature)
+                elem / width if idx % 2 == 0 else elem / height
+                for idx, elem in enumerate(feature)
             ]
             re_lst.append(normalized_feature)
             pair.append([i, j])


### PR DESCRIPTION
## Summary
- handle optional `gradio` import and create dummy progress when absent
- guard Gradio interface creation so the rest of the code can run without the package
- normalize pair features with width and height

## Testing
- `pytest -q app/test_pipline.py::test_process_image -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68522bfaa9ec832bbfe13dcb9fc05e84